### PR TITLE
Enable request throttling to stop connection resets

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -4,14 +4,17 @@ import requests
 from requests.exceptions import HTTPError
 import csv
 import httplib
+import requests_cache
+import time
 
 linkSet = ['http://gsa.gov']
 outputFile= open('scraperOutput.csv', 'w+')
 output_writer=csv.writer(outputFile, lineterminator='\n')
 output_writer.writerow(['url'])
+requests_cache.install_cache('test_cache', backend='sqlite')
 
+counter = 0
 for i in linkSet:
-	print("processing " + i)
 	request = urllib2.Request(i)
 	try:
 		response = urllib2.urlopen(request)
@@ -19,10 +22,17 @@ for i in linkSet:
 		for a in soup.findAll('a'):
 			try:
 				if '.gov' in a['href']:
+					if counter % 1000 == 0 and not counter == 0:
+						time.sleep(180)
 					if a['href'] not in linkSet:
-						linkSet.append(a['href'])
-						outputLink = str(a['href'])
-						output_writer.writerow([outputLink])
+						if not str(a['href']).startswith("mailto"):
+							linkSet.append(a['href'])
+							outputLink = str(a['href'])
+							output_writer.writerow([outputLink])
+							counter += 1
+							print("processed link %i" %(counter))
+						else:
+							continue
 			except KeyError:
 				continue
 	except urllib2.HTTPError, e:
@@ -33,6 +43,4 @@ for i in linkSet:
 		continue
 	except httplib.BadStatusLine, e:
 		continue
-
-
-print linkSet
+print('scan complete')


### PR DESCRIPTION
Adding a timer that pauses the script after every 1000 requests for three minutes to prevent the server from refusing further responses. Also changes final printed line to bring script into line with Python 3 standards
